### PR TITLE
Highlight current section in the header with an underline

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,12 +13,15 @@
         </span>
       </label>
 
+      {% assign url_parts = page.url | split: '/' %}
+      {% assign base_url = url_parts[1] %}
+
       <div class="trigger">
-        <a class="page-link" href="/introduction/">Introduction</a>
-        <a class="page-link" href="/basics/">Basics</a>
-        <a class="page-link" href="/canvas/">Canvas</a>
-        <a class="page-link" href="/layout/">Layout</a>
-        <a class="page-link" href="/widget/">Widget</a>
+        <a class="page-link{% if base_url == "introduction" %} active{% endif %}" href="/introduction/">Introduction</a>
+        <a class="page-link{% if base_url == "basics" %} active{% endif %}" href="/basics/">Basics</a>
+        <a class="page-link{% if base_url == "canvas" %} active{% endif %}" href="/canvas/">Canvas</a>
+        <a class="page-link{% if base_url == "layout" %} active{% endif %}" href="/layout/">Layout</a>
+        <a class="page-link{% if base_url == "widget" %} active{% endif %}" href="/widget/">Widget</a>
       </div>
     </nav>
   </div>

--- a/css/home.css
+++ b/css/home.css
@@ -127,3 +127,7 @@ code.since {
   background-color: #fff;
 }
 
+
+.page-link.active {
+    text-decoration: underline;
+}


### PR DESCRIPTION
Underline the current section of the website in the header. Useful to know what we're reading.
I was reading the site for the first time and the navigation wasn't clear, I didn't really understood which section I was reading. This change clarifies it

See the example in this screenshot:

![Screenshot 2020-02-05 at 23 56 28](https://user-images.githubusercontent.com/122749/73890827-25276880-4873-11ea-9073-bbad2fd648fe.png)
