### PR TITLE
Typofix: remove some apostrophes

### DIFF
--- a/basics/windows.md
+++ b/basics/windows.md
@@ -13,7 +13,7 @@ allows you to show your window and run the application at the same time.
 If you wish to show a second window you must only call the `Show()`
 function. This is illustrated in the `showAnother` function.
 
-By default a window will be the right size to show it's content
+By default a window will be the right size to show its content
 by checking the `MinSize()` function (more on that in later examples).
 You can set a larger size by calling the `Window.Resize()` function.
 

--- a/canvas/line.md
+++ b/canvas/line.md
@@ -8,7 +8,7 @@ order: 3
 
 The `canvas.Line` object draws a line from the `Position1` (default
 is top, left) to `Position2` (default is bottom, right).
-You specify it's colour and can vary the stroke width which otherwise
+You specify its colour and can vary the stroke width which otherwise
 defaults to `1`.
 
 A line position can be manipulated using the `Position1` or `Position2`

--- a/introduction/learning.md
+++ b/introduction/learning.md
@@ -15,7 +15,7 @@ but none should be beyond a proficient programmer. Every step of the
 way you can copy the examples into your IDE and see them in action.
 
 By the end of this tour you will be know all of the building blocks
-of Fyne and it's tools. We can't wait to see what you build.
+of Fyne and its tools. We can't wait to see what you build.
 
 If at any point you want to start giving back we welcome contributions,
 bug reports and conversations with people that are using the toolkit.

--- a/layout/boxlayout.md
+++ b/layout/boxlayout.md
@@ -19,13 +19,13 @@ row or column with optional spaces to assist alignment.
 
 A horizontal box layout, created with `layout.NewHBoxLayout()` creates
 an arrangement of items in a single row. Every item in the box will
-have it's width set to it's `MinSize().Width` and the height will be
+have its width set to its `MinSize().Width` and the height will be
 equal for all items, the largest of all the `MinSize().Height` values.
 The layout can be used in a container or you can use the box widget
 `widget.NewHBox()`.
 
 A vertical box layout is similar but it arranges items in a column.
-Each item will have it's height set to minimum and all the widths will
+Each item will have its height set to minimum and all the widths will
 be equal, set to the largest of the minimum widths.
 
 To create an expanding space between elements (so that some are left

--- a/layout/centerlayout.md
+++ b/layout/centerlayout.md
@@ -6,7 +6,7 @@ order: 6
 
 ---
 
-`layout.CenterLayout` organises all items in it's container to be
+`layout.CenterLayout` organises all items in its container to be
 centered in the available space. The objects will be drawn in the order
 the are passed to the container, with the last being drawn top-most.
 

--- a/widget/entry.md
+++ b/widget/entry.md
@@ -9,7 +9,7 @@ order: 4
 The entry widget is used for user input of simple text content.
 An entry can be created with a simple `widget.NewEntry()`
 constructing function. When you create the widget keep a
-reference so that you can access it's `Text` field later.
+reference so that you can access its `Text` field later.
 It is also possible to use the `OnChanged` callback function
 to be notified every time the content changes.
 

--- a/widget/form.md
+++ b/widget/form.md
@@ -7,7 +7,7 @@ order: 6
 ---
 
 The form widget is used to lay out many input fields with
-labels and optional cancel and submit buttons. In it's most
+labels and optional cancel and submit buttons. In its most
 bare form it aligns labels to the left of each input widget.
 By setting OnCancel or OnSubmit the form will add a button
 bar with the specified handlers called when appropriate.

--- a/widget/form.md
+++ b/widget/form.md
@@ -15,7 +15,7 @@ bar with the specified handlers called when appropriate.
 The widget can be created with `widget.NewForm(...)` passing
 a list of `widget.FormItem`s, or by using the
 `&widget.Form{}` syntax illustrated in the example.
-There is also a helpful 'Form.Append(label, widget)` that
+There is also a helpful `Form.Append(label, widget)` that
 can be used for an alternative syntax.
 
 In this example we create two entries, one of which is a


### PR DESCRIPTION
I removed a few apostrophes from "it's" where they didn't belong grammatically.